### PR TITLE
Cors headers for Core API.

### DIFF
--- a/core/settings/settings.py
+++ b/core/settings/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'rest_framework',
+    'corsheaders',
 
     'web',
 ]
@@ -46,6 +47,7 @@ INSTALLED_APPS = [
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -133,3 +135,6 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.BrowsableAPIRenderer',
     )
 }
+
+# CORE headers
+CORS_ORIGIN_ALLOW_ALL = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ requests
 djangorestframework
 markdown
 django-filter
+django-cors-headers
 coverage


### PR DESCRIPTION
Allow external call to the Core API.
django-cors-headers
https://github.com/ottoyiu/django-cors-headers/